### PR TITLE
Tracing middleware, specs, CI config, docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,8 @@ matrix:
   allow_failures:
     - rvm: ruby-head
 
+before_install:
+  - gem update --system
+
 script:
   - bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,5 @@ matrix:
   allow_failures:
     - rvm: ruby-head
 
-before_install:
-  - gem update --system
-  - bundle install
-
 script:
   - bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: ruby
+rvm:
+  - ruby-head
+  - ruby-2.5.0
+  - jruby-9.1.7.0
+
+matrix:
+  allow_failures:
+    - rvm: ruby-head
+
+before_install:
+  - gem update --system
+  - bundle install
+
+script:
+  - bundle exec rake

--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+# ActionSubscriber::OpenTracing
+
+Tracing for ActionSubscriber
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'action_subscriber-opentracing'
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install action_subscriber-opentracing
+
+## Usage
+
+After you have initialized the OpenTracing gem, simply add the middleware
+provided by this gem to `ActionSubscriber`'s middleware stack and you're good
+to go:
+
+```ruby
+::ActionSubscriber.config.middleware.use(::ActionSubscriber::OpenTracing::Middleware)
+```
+
+## Development
+
+After checking out the repo, run `bin/setup` to install dependencies. Then, run
+`rake spec` to run the tests. You can also run `bin/console` for an interactive
+prompt that will allow you to experiment.
+
+To install this gem onto your local machine, run `bundle exec rake install`. To
+release a new version, update the version number in `version.rb`, and then run
+`bundle exec rake release`, which will create a git tag for the version, push
+git commits and tags, and push the `.gem` file to
+[rubygems.org](https://rubygems.org).
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at
+https://github.com/mxenabled/action_subscriber-opentracing.
+
+## License
+
+The gem is available as open source under the terms of the [MIT
+License](https://opensource.org/licenses/MIT).

--- a/action_subscriber-opentracing.gemspec
+++ b/action_subscriber-opentracing.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "opentracing"
 
-  spec.add_development_dependency "bundler", "~> 1.17"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "mad_rubocop"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/action_subscriber-opentracing.gemspec
+++ b/action_subscriber-opentracing.gemspec
@@ -37,8 +37,11 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "opentracing"
 
+  spec.add_development_dependency "action_subscriber", "~> 5.1.3"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "mad_rubocop"
+  spec.add_development_dependency "opentracing_test_tracer"
+  spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/lib/action_subscriber/opentracing.rb
+++ b/lib/action_subscriber/opentracing.rb
@@ -1,8 +1,7 @@
+require "action_subscriber/opentracing/middleware"
 require "action_subscriber/opentracing/version"
 
 module ActionSubscriber
   module OpenTracing
-    class Error < StandardError; end
-    # Your code goes here...
   end
 end

--- a/lib/action_subscriber/opentracing/middleware.rb
+++ b/lib/action_subscriber/opentracing/middleware.rb
@@ -1,0 +1,29 @@
+require "opentracing"
+
+module ActionSubscriber
+  module OpenTracing
+    class Middleware
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        operation = "#{env.subscriber}##{env.action}"
+        parent = ::OpenTracing.extract(::OpenTracing::FORMAT_TEXT_MAP, env.headers)
+        published_at = env.headers["published_at"]
+
+        options = {}
+        options[:references] = [::OpenTracing::Reference.follows_from(parent)] if parent
+        options[:tags] = {}
+        options[:tags]["routing_key"] = env.routing_key
+        options[:tags]["published_at"] = published_at if published_at
+
+        result = nil
+        ::OpenTracing.start_active_span(operation, options) do
+          result = @app.call(env)
+        end
+        result
+      end
+    end
+  end
+end

--- a/spec/action_subscriber/opentracing/middleware_spec.rb
+++ b/spec/action_subscriber/opentracing/middleware_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe ActionSubscriber::OpenTracing::Middleware do
+  let(:app) { lambda { |env| env } }
+  let(:middleware) { described_class.new(app) }
+  let(:env) { ::ActionSubscriber::Middleware::Env.new(FakeSubscriber, nil, properties) }
+
+  let(:properties) {
+    {
+      :action => "fake_action",
+      :delivery_tag => nil,
+      :exchange => nil,
+      :message_id => nil,
+      :queue => nil,
+      :content_type => "application/protocol-buffers",
+      :routing_key => "test.testing",
+      :headers => {
+        "published_at" => Time.now.strftime("%F %T.%3N %Z")
+      }
+    }
+  }
+
+  before { ::OpenTracing.global_tracer = ::OpenTracingTestTracer.build }
+  after { ::OpenTracing.global_tracer = ::OpenTracing::Tracer.new }
+
+  describe "#call" do
+    it "starts a span" do
+      middleware.call(env)
+      expect(::OpenTracing.global_tracer.spans.size).to be 1
+    end
+
+    it "uses the subscriber and action in the operation name" do
+      middleware.call(env)
+      expect(::OpenTracing.global_tracer.spans.first.operation_name).to eq "FakeSubscriber#fake_action"
+    end
+
+    it "tags the active span with routing key and applicable headers" do
+      middleware.call(env)
+      tags = ::OpenTracing.global_tracer.spans.first.tags
+      expect(tags["routing_key"]).to eq properties[:routing_key]
+      expect(tags["published_at"]).to eq properties[:headers]["published_at"]
+    end
+  end
+end

--- a/spec/action_subscriber/opentracing_spec.rb
+++ b/spec/action_subscriber/opentracing_spec.rb
@@ -1,9 +1,5 @@
-RSpec.describe ActionSubscriber::Opentracing do
+RSpec.describe ActionSubscriber::OpenTracing do
   it "has a version number" do
-    expect(ActionSubscriber::Opentracing::VERSION).not_to be nil
-  end
-
-  it "does something useful" do
-    expect(false).to eq(true)
+    expect(ActionSubscriber::OpenTracing::VERSION).not_to be nil
   end
 end

--- a/spec/fake_subscriber.rb
+++ b/spec/fake_subscriber.rb
@@ -1,0 +1,5 @@
+class FakeSubscriber
+  def fake_action(arg)
+    arg
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,11 @@
+require "opentracing"
+require "opentracing_test_tracer"
+require "action_subscriber"
+
 require "bundler/setup"
 require "action_subscriber/opentracing"
+
+require "fake_subscriber.rb"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
Right now the repo is made up of what `bundle gem action_subscriber-opentracing` generated, this PR includes everything else needed in the gem that's not boilerplate.

No integration/end-to-end tests in this PR since unit test were quicker to get going with, but if we feel strongly about needing a full end-to-end test I can bring in AS, Rabbit, etc. and get that going.

👀 @film42, @ETetzlaff, @abrandoned 