### PR TITLE
Tags as per the specification

### DIFF
--- a/lib/action_subscriber/opentracing/middleware.rb
+++ b/lib/action_subscriber/opentracing/middleware.rb
@@ -17,9 +17,10 @@ module ActionSubscriber
         options = {}
         options[:references] = [::OpenTracing::Reference.follows_from(parent)] if parent
         options[:tags] = {}
-        options[:tags]["routing_key"] = env.routing_key
-        options[:tags]["published_at"] = published_at if published_at
-        options[:tags]["processed_at"] = Time.now.strftime("%F %T.%3N %Z")
+        options[:tags]["span.kind"] = "consumer"
+        options[:tags]["message_bus.destination"] = env.routing_key
+        options[:tags]["message_bus.published_at"] = published_at if published_at
+        options[:tags]["message_bus.processed_at"] = Time.now.strftime("%F %T.%3N %Z")
 
         result = nil
         ::OpenTracing.start_active_span(operation, options) do

--- a/spec/action_subscriber/opentracing/middleware_spec.rb
+++ b/spec/action_subscriber/opentracing/middleware_spec.rb
@@ -35,9 +35,10 @@ RSpec.describe ActionSubscriber::OpenTracing::Middleware do
     it "tags the active span with routing key and applicable headers/information" do
       middleware.call(env)
       tags = ::OpenTracing.global_tracer.spans.first.tags
-      expect(tags["routing_key"]).to eq properties[:routing_key]
-      expect(tags["published_at"]).to eq properties[:headers]["published_at"]
-      expect(tags["processed_at"]).to_not be_nil
+      expect(tags["span.kind"]).to eq "consumer"
+      expect(tags["message_bus.destination"]).to eq properties[:routing_key]
+      expect(tags["message_bus.published_at"]).to eq properties[:headers]["published_at"]
+      expect(tags["message_bus.processed_at"]).to_not be_nil
     end
 
     it "references parent span as follows_from when tracing context is found in the headers" do


### PR DESCRIPTION
Additional information on the standard tags can be found here: https://opentracing.io/specification/conventions/. The `message_bus.published_at` and `message_bus.processed_at` tags are my own but stick to the namespacing convention.

@film42 @ETetzlaff